### PR TITLE
feat: Fix index getServerSideProps cache reset

### DIFF
--- a/components/post/create/CreatePost.tsx
+++ b/components/post/create/CreatePost.tsx
@@ -1,6 +1,6 @@
 /**
  * 생성일: 2022.02.15
- * 수정일: 2022.03.05
+ * 수정일: 2022.03.16
  */
 
 import { gql, useApolloClient, useMutation } from '@apollo/client';
@@ -37,14 +37,15 @@ export default function CreatePost() {
     const { seeMyInfo } = useMyInfo();
     const { cache } = useApolloClient();
     const { register, handleSubmit, formState: { errors } } = useForm<IForm>();
+
     // createPost Mutation 처리 후 cache 수정작업
     const createPostCompleted = ({ createPost }: IMutationResults) => {
-        const { ok, error } = createPost;
+        const { ok, error }: any = createPost;
         if (!ok) {
             alert(error);
+            router.replace("/");
             return;
         };
-        // 어차피 index로 보내지면 index Component에서 fetch가 일어나므로 cache 수정할 필요없다.
 
         cache.modify({
             id: `User:${seeMyInfo?.id}`,

--- a/components/post/edit/EditPost.tsx
+++ b/components/post/edit/EditPost.tsx
@@ -62,13 +62,13 @@ export default function EditPost({ postId, title, description, openChatLink, app
             id: `Post:${postId}`,
             fields: {
                 title() {
-                    return editedTitle
+                    return editedTitle;
                 },
                 description() {
-                    return editedDescription
+                    return editedDescription;
                 },
                 openChatLink() {
-                    return editedOpenChatLink
+                    return editedOpenChatLink;
                 }
             }
         });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -80,6 +80,7 @@ const Home: NextPage = () => {
 };
 
 export async function getServerSideProps({ req }: GetServerSidePropsContext) {
+  client.cache.reset();
   await client.query({
     query: SEE_POSTS_QUERY,
     variables: {
@@ -89,9 +90,8 @@ export async function getServerSideProps({ req }: GetServerSidePropsContext) {
       headers: {
         token: req.cookies["TOKEN"]
       }
-    }
+    },
   });
-
   return {
     props: {
       initialCache: client.cache.extract()


### PR DESCRIPTION
- 클라이언트 측에서 게시물 추가, 편집을 하고 cache를 수정을 했을 때 서버 측에서는 클라이언트가 가지는 cache와는 다른 자신만의 cache에 있는 데이터를 return하므로 일치하지 않아 새로고침시 게시물 추가, 편집사항이 반영되지 않는 버그가 있어서 SSR 데이터 요청 전 cache를 reset시켜서 서버측 자신의 cache의 데이터를 끌어다 쓰게 하는 것이 아닌 다시 백엔드에 요청을 보내게 함